### PR TITLE
fix: pin actionsforge hygiene workflows to @main

### DIFF
--- a/.github/workflows/commitmsg-conform.yml
+++ b/.github/workflows/commitmsg-conform.yml
@@ -8,4 +8,4 @@ permissions:
   pull-requests: read
 jobs:
   commitmsg-conform:
-    uses: actionsforge/actions/.github/workflows/commitmsg-conform.yml
+    uses: actionsforge/actions/.github/workflows/commitmsg-conform.yml@main

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -8,4 +8,4 @@ permissions:
   pull-requests: read
 jobs:
   markdown-lint:
-    uses: actionsforge/actions/.github/workflows/markdown-lint.yml
+    uses: actionsforge/actions/.github/workflows/markdown-lint.yml@main


### PR DESCRIPTION
## Summary
- Restore `@main` pin on actionsforge markdown-lint and commitmsg-conform callers
- Earlier migration dropped the ref due to a Perl replacement bug

## Test plan
- [ ] Hygiene checks run and pass

Closes #50